### PR TITLE
修复工程路径带空格时，路径参数解析错误无法调用py工具的bug

### DIFF
--- a/addons/config_table_manager.daylily-zeleen/table_tools/xlsx.gd
+++ b/addons/config_table_manager.daylily-zeleen/table_tools/xlsx.gd
@@ -41,7 +41,7 @@ func _parse_table_file(xlsx_file: String, options: PackedStringArray) -> Error:
 		return _last_parse_error
 
 	var output := []
-	var err := OS.execute("python", ['"%s"' % _py_tool_path, "--dump_json", '"%s"' % ProjectSettings.globalize_path(xlsx_file), '"%s"' % _tmp_json_path], output, true)
+	var err := OS.execute("python", [_py_tool_path, "--dump_json", ProjectSettings.globalize_path(xlsx_file), _tmp_json_path], output, true)
 	if err != OK:
 		_Log.error([_Localize.translate("无法解析xlsx文件: "), xlsx_file, " - ", "\n".join(output)])
 		_last_parse_error = FAILED
@@ -234,7 +234,7 @@ func _generate_table_file(save_path: String, header: _TableHeader, data_rows: Ar
 	fa.close()
 
 	var output := []
-	var err := OS.execute("python", ['"%s"' % _py_tool_path, "--override_xlsx", '"%s"' % _tmp_json_path, '"%s"' % ProjectSettings.globalize_path(save_path)], output, true)
+	var err := OS.execute("python", [_py_tool_path, "--override_xlsx", _tmp_json_path, save_path], output, true)
 	if err != OK:
 		_Log.error([_Localize.translate("无法覆盖xlsx文件: "), save_path, " - ", "\n".join(output)])
 		_last_parse_error = FAILED


### PR DESCRIPTION
4.4.1版本的os.execute()里提到“arguments 按给定顺序使用，用空格分隔，并用引号包裹。”所以这里两处不需要手动构造双引号。续：啊手滑把237行里的ProjectSettings.globalize_path给去掉了，那个其实不用去掉的，不去掉安全一点，我手快去掉了。